### PR TITLE
feat: add support for folders

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -159,4 +159,17 @@ describe("api client", () => {
       "/api/file_preview?filename=subdir%2Ftest.ctb",
     );
   });
+
+  it("creates a directory with POST", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    } as Response);
+
+    await api.createDirectory("foo/bar", "new_dir");
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/create_directory?path=foo%2Fbar&name=new_dir",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
 });

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -179,7 +179,9 @@ describe("api client", () => {
       json: () => Promise.resolve({ success: true }),
     } as Response);
 
-    const file = new File(["x"], "test.ctb", { type: "application/octet-stream" });
+    const file = new File(["x"], "test.ctb", {
+      type: "application/octet-stream",
+    });
     await api.uploadFile(file, "foo/bar");
     expect(fetch).toHaveBeenCalledWith(
       "/api/upload_file?path=foo%2Fbar",

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -172,4 +172,18 @@ describe("api client", () => {
       expect.objectContaining({ method: "POST" }),
     );
   });
+
+  it("uploads a file with path query", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    } as Response);
+
+    const file = new File(["x"], "test.ctb", { type: "application/octet-stream" });
+    await api.uploadFile(file, "foo/bar");
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/upload_file?path=foo%2Fbar",
+      expect.objectContaining({ method: "POST", body: expect.any(FormData) }),
+    );
+  });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -80,13 +80,14 @@ export const api = {
     return `/api/file_preview?filename=${encodeURIComponent(filename)}`;
   },
 
-  async uploadFile(file: File): Promise<void> {
+  async uploadFile(file: File, path: string = "."): Promise<void> {
     const formData = new FormData();
     formData.append("file", file);
     const csrf = getCsrfToken();
     const headers: Record<string, string> = {};
     if (csrf) headers["X-CSRFToken"] = csrf;
-    const res = await fetch("/api/upload_file", {
+    const q = new URLSearchParams({ path });
+    const res = await fetch(`/api/upload_file?${q.toString()}`, {
       method: "POST",
       headers,
       body: formData,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -103,6 +103,16 @@ export const api = {
     );
   },
 
+  async createDirectory(parentPath: string, name: string): Promise<void> {
+    const params = new URLSearchParams({
+      path: parentPath,
+      name,
+    });
+    await apiFetch(`/api/create_directory?${params.toString()}`, {
+      method: "POST",
+    });
+  },
+
   async printerCommand(
     command: "start_print" | "pause_print" | "resume_print" | "cancel_print",
     filename?: string,

--- a/frontend/src/pages/Files.tsx
+++ b/frontend/src/pages/Files.tsx
@@ -1,5 +1,5 @@
-import { useState, useRef } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState, useRef, useEffect } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   api,
   formatTime,
@@ -9,6 +9,15 @@ import {
 import { FileDetailDialog } from "@/components/FileDetailDialog";
 import { Button } from "@/components/ui/button";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { toast } from "@/components/ui/sonner";
+import {
   Folder,
   FileText,
   Layers,
@@ -16,6 +25,7 @@ import {
   Upload,
   Loader2,
   ArrowLeft,
+  FolderPlus,
 } from "lucide-react";
 
 function FileIcon({ canBePrinted }: { canBePrinted: boolean }) {
@@ -27,6 +37,8 @@ export default function Files() {
   const [currentPath, setCurrentPath] = useState(".");
   const [selectedFile, setSelectedFile] = useState<FileEntry | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [newFolderOpen, setNewFolderOpen] = useState(false);
+  const [newFolderName, setNewFolderName] = useState("");
   const fileInputRef = useRef<HTMLInputElement>(null);
   const queryClient = useQueryClient();
 
@@ -34,6 +46,23 @@ export default function Files() {
     queryKey: ["files", currentPath],
     queryFn: () => api.listFiles(currentPath),
   });
+
+  const createFolderMutation = useMutation({
+    mutationFn: (name: string) => api.createDirectory(currentPath, name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["files", currentPath] });
+      toast.success("Folder created");
+      setNewFolderOpen(false);
+      setNewFolderName("");
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || "Could not create folder");
+    },
+  });
+
+  useEffect(() => {
+    if (!newFolderOpen) setNewFolderName("");
+  }, [newFolderOpen]);
 
   const handleDirectoryClick = (dirname: string) => {
     if (dirname === "..") {
@@ -60,6 +89,12 @@ export default function Files() {
     e.target.value = "";
   };
 
+  const handleCreateFolder = () => {
+    const name = newFolderName.trim();
+    if (!name) return;
+    createFolderMutation.mutate(name);
+  };
+
   return (
     <div className="container py-6">
       <div className="mb-6 flex items-center justify-between">
@@ -69,13 +104,22 @@ export default function Files() {
             {currentPath === "." ? "/" : `/${currentPath}`}
           </p>
         </div>
-        <div>
+        <div className="flex flex-wrap items-center gap-2">
           <input
             ref={fileInputRef}
             type="file"
             className="hidden"
             onChange={handleUpload}
           />
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={() => setNewFolderOpen(true)}
+          >
+            <FolderPlus className="h-3.5 w-3.5" />
+            <span className="hidden sm:inline">New folder</span>
+          </Button>
           <Button
             variant="outline"
             size="sm"
@@ -166,6 +210,56 @@ export default function Files() {
         open={dialogOpen}
         onOpenChange={setDialogOpen}
       />
+
+      <Dialog open={newFolderOpen} onOpenChange={setNewFolderOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>New folder</DialogTitle>
+            <DialogDescription>
+              Create a folder in{" "}
+              <span className="font-mono text-foreground">
+                {currentPath === "." ? "/" : `/${currentPath}`}
+              </span>
+              .
+            </DialogDescription>
+          </DialogHeader>
+          <input
+            autoFocus
+            value={newFolderName}
+            onChange={(e) => setNewFolderName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleCreateFolder();
+            }}
+            placeholder="Folder name"
+            className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setNewFolderOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              disabled={
+                !newFolderName.trim() || createFolderMutation.isPending
+              }
+              onClick={handleCreateFolder}
+            >
+              {createFolderMutation.isPending ? (
+                <>
+                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  Creating…
+                </>
+              ) : (
+                "Create"
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/src/pages/Files.tsx
+++ b/frontend/src/pages/Files.tsx
@@ -84,7 +84,7 @@ export default function Files() {
   const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    await api.uploadFile(file);
+    await api.uploadFile(file, currentPath);
     queryClient.invalidateQueries({ queryKey: ["files", currentPath] });
     e.target.value = "";
   };

--- a/frontend/src/pages/Files.tsx
+++ b/frontend/src/pages/Files.tsx
@@ -243,9 +243,7 @@ export default function Files() {
             </Button>
             <Button
               type="button"
-              disabled={
-                !newFolderName.trim() || createFolderMutation.isPending
-              }
+              disabled={!newFolderName.trim() || createFolderMutation.isPending}
               onClick={handleCreateFolder}
             >
               {createFolderMutation.isPending ? (

--- a/mariner/server/__init__.py
+++ b/mariner/server/__init__.py
@@ -3,7 +3,7 @@ import multiprocessing
 import os
 from typing import Dict
 
-from flask import render_template
+from flask import abort, render_template
 from waitress import serve
 
 from mariner import config
@@ -21,8 +21,7 @@ from itertools import chain
 flask_app.register_blueprint(api_blueprint)
 
 
-@flask_app.route("/", methods=["GET"])
-def index() -> str:
+def render_index() -> str:
     template_vars: Dict[str, str] = {
         "supported_extensions": ",".join(get_supported_extensions()),
     }
@@ -30,6 +29,19 @@ def index() -> str:
     if printer_display_name is not None:
         template_vars["printer_display_name"] = printer_display_name
     return render_template("index.html", **template_vars)
+
+
+@flask_app.route("/", methods=["GET"])
+def index() -> str:
+    return render_index()
+
+
+@flask_app.get("/<path:spa_path>")
+def spa_fallback(spa_path: str) -> str:
+    # Let /api/* hit the API blueprint; everything else is a client-side route.
+    if spa_path == "api" or spa_path.startswith("api/"):
+        abort(404)
+    return render_index()
 
 
 class CacheBootstrapper(multiprocessing.Process):

--- a/mariner/server/api.py
+++ b/mariner/server/api.py
@@ -273,7 +273,25 @@ def upload_file() -> Union[str, Response]:
     if get_file_extension(file_filename) not in get_supported_extensions():
         abort(400)
     filename = secure_filename(file_filename)
-    file.save(str(config.get_files_directory() / filename))
+
+    path_parameter = str(request.args.get("path", "."))
+    files_directory_resolved = config.get_files_directory().resolve()
+    parent = (config.get_files_directory() / path_parameter).resolve()
+    if (
+        files_directory_resolved not in parent.parents
+        and parent != files_directory_resolved
+    ):
+        abort(400)
+    if not os.path.isdir(parent):
+        abort(400)
+
+    dest_path = (parent / filename).resolve()
+    try:
+        dest_path.relative_to(files_directory_resolved)
+    except ValueError:
+        abort(400)
+
+    file.save(str(dest_path))
     os.sync()
     return jsonify({"success": True})
 

--- a/mariner/server/api.py
+++ b/mariner/server/api.py
@@ -296,6 +296,43 @@ def delete_file() -> Union[str, Response]:
     return jsonify({"success": True})
 
 
+@api.route("/create_directory", methods=["POST"])
+def create_directory() -> Union[str, Response]:
+    path_parameter = str(request.args.get("path", "."))
+    raw_name = request.args.get("name", type=str)
+    if raw_name is None or not raw_name.strip():
+        abort(400)
+    name_str = raw_name.strip()
+    if "/" in name_str or "\\" in name_str or name_str in (".", ".."):
+        abort(400)
+
+    safe_name = secure_filename(name_str)
+    if not safe_name or safe_name in (".", ".."):
+        abort(400)
+
+    files_directory_resolved = config.get_files_directory().resolve()
+    parent = (config.get_files_directory() / path_parameter).resolve()
+    if (
+        files_directory_resolved not in parent.parents
+        and parent != files_directory_resolved
+    ):
+        abort(400)
+    if not os.path.isdir(parent):
+        abort(400)
+
+    new_path = (parent / safe_name).resolve()
+    try:
+        new_path.relative_to(files_directory_resolved)
+    except ValueError:
+        abort(400)
+
+    try:
+        os.mkdir(new_path)
+    except FileExistsError:
+        abort(400)
+    return jsonify({"success": True})
+
+
 @api.route("/file_preview", methods=["GET"])
 def file_preview() -> Response:
     filename = str(request.args.get("filename"))

--- a/mariner/tests/test_server.py
+++ b/mariner/tests/test_server.py
@@ -495,3 +495,14 @@ class MarinerServerTest(TestCase):
                 supported_extensions=ANY,
             )
         expect(response.status_code).to_equal(200)
+
+    def test_get_spa_client_route_serves_index(self) -> None:
+        with patch(
+            "mariner.server.render_template", return_value=""
+        ) as render_template_mock:
+            response = self.client.get("/files")
+            render_template_mock.assert_called_with(
+                "index.html",
+                supported_extensions=ANY,
+            )
+        expect(response.status_code).to_equal(200)

--- a/mariner/tests/test_server.py
+++ b/mariner/tests/test_server.py
@@ -429,6 +429,41 @@ class MarinerServerTest(TestCase):
         response = self.client.post("/api/delete_file?filename=../../etc/passwd")
         expect(response.status_code).to_equal(400)
 
+    def test_create_directory(self) -> None:
+        response = self.client.post(
+            "/api/create_directory?path=.&name=my_project"
+        )
+        expect(response.status_code).to_equal(200)
+        expect(response.get_json()).to_equal({"success": True})
+        expect(
+            os.path.isdir(config.get_files_directory() / "my_project")
+        ).to_equal(True)
+
+    def test_create_directory_under_subdirectory(self) -> None:
+        self.fs.create_dir("/mnt/usb_share/nested/")
+        response = self.client.post(
+            "/api/create_directory?path=nested&name=sub"
+        )
+        expect(response.status_code).to_equal(200)
+        expect(
+            os.path.isdir(config.get_files_directory() / "nested" / "sub")
+        ).to_equal(True)
+
+    def test_create_directory_duplicate(self) -> None:
+        self.fs.create_dir("/mnt/usb_share/exists/")
+        response = self.client.post("/api/create_directory?path=.&name=exists")
+        expect(response.status_code).to_equal(400)
+
+    def test_create_directory_invalid_parent_path(self) -> None:
+        response = self.client.post(
+            "/api/create_directory?path=../etc&name=bad"
+        )
+        expect(response.status_code).to_equal(400)
+
+    def test_create_directory_missing_name(self) -> None:
+        response = self.client.post("/api/create_directory?path=.")
+        expect(response.status_code).to_equal(400)
+
     def test_get_index(self) -> None:
         with patch(
             "mariner.server.render_template", return_value=""

--- a/mariner/tests/test_server.py
+++ b/mariner/tests/test_server.py
@@ -401,6 +401,27 @@ class MarinerServerTest(TestCase):
             str(config.get_files_directory() / "etc_passwd.ctb")
         )
 
+    def test_upload_file_to_subdirectory(self) -> None:
+        self.fs.create_dir("/mnt/usb_share/uploads/")
+        data = {"file": (io.BytesIO(b"abcdef"), "myfile.ctb")}
+        with patch.object(FileStorage, "save") as save_file_mock:
+            response = self.client.post("/api/upload_file?path=uploads", data=data)
+        expect(response.status_code).to_equal(200)
+        expect(response.get_json()).to_equal({"success": True})
+        save_file_mock.assert_called_once_with(
+            str(config.get_files_directory() / "uploads" / "myfile.ctb")
+        )
+
+    def test_upload_file_with_invalid_parent_path(self) -> None:
+        data = {"file": (io.BytesIO(b"abcdef"), "myfile.ctb")}
+        response = self.client.post("/api/upload_file?path=../../etc", data=data)
+        expect(response.status_code).to_equal(400)
+
+    def test_upload_file_to_missing_directory(self) -> None:
+        data = {"file": (io.BytesIO(b"abcdef"), "myfile.ctb")}
+        response = self.client.post("/api/upload_file?path=no_such_dir", data=data)
+        expect(response.status_code).to_equal(400)
+
     def test_delete_file(self) -> None:
         expect(os.path.exists(config.get_files_directory() / "mariner.ctb")).to_equal(
             False

--- a/mariner/tests/test_server.py
+++ b/mariner/tests/test_server.py
@@ -451,24 +451,20 @@ class MarinerServerTest(TestCase):
         expect(response.status_code).to_equal(400)
 
     def test_create_directory(self) -> None:
-        response = self.client.post(
-            "/api/create_directory?path=.&name=my_project"
-        )
+        response = self.client.post("/api/create_directory?path=.&name=my_project")
         expect(response.status_code).to_equal(200)
         expect(response.get_json()).to_equal({"success": True})
-        expect(
-            os.path.isdir(config.get_files_directory() / "my_project")
-        ).to_equal(True)
+        expect(os.path.isdir(config.get_files_directory() / "my_project")).to_equal(
+            True
+        )
 
     def test_create_directory_under_subdirectory(self) -> None:
         self.fs.create_dir("/mnt/usb_share/nested/")
-        response = self.client.post(
-            "/api/create_directory?path=nested&name=sub"
-        )
+        response = self.client.post("/api/create_directory?path=nested&name=sub")
         expect(response.status_code).to_equal(200)
-        expect(
-            os.path.isdir(config.get_files_directory() / "nested" / "sub")
-        ).to_equal(True)
+        expect(os.path.isdir(config.get_files_directory() / "nested" / "sub")).to_equal(
+            True
+        )
 
     def test_create_directory_duplicate(self) -> None:
         self.fs.create_dir("/mnt/usb_share/exists/")
@@ -476,9 +472,7 @@ class MarinerServerTest(TestCase):
         expect(response.status_code).to_equal(400)
 
     def test_create_directory_invalid_parent_path(self) -> None:
-        response = self.client.post(
-            "/api/create_directory?path=../etc&name=bad"
-        )
+        response = self.client.post("/api/create_directory?path=../etc&name=bad")
         expect(response.status_code).to_equal(400)
 
     def test_create_directory_missing_name(self) -> None:


### PR DESCRIPTION
Add support for folders in the file management screen, useful for handling projects or anything that should stay together.

Also fix a small issue while refreshing pages when in the file browser.